### PR TITLE
Point at latest version of forked vulcand

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,11 @@
 FROM alpine
 
 RUN apk --update add go git \
-  && ORG_PATH="github.com/Financial-Times/" \
-  && REPO_PATH="${ORG_PATH}ft-vulcan" \
   && export GOPATH=/gopath \
-  && export PATH=$PATH:$GOPATH/bin \
-  && mkdir -p $GOPATH/src/${ORG_PATH} \
-  && ln -s ${PWD} $GOPATH/src/${REPO_PATH} \
-  && go get github.com/mailgun/vulcand \
-  # checkout older version of vulcan \
-  && cd $GOPATH/src/github.com/mailgun/vulcand \
-  && git checkout 791285c97cbf28f8eac1ef7222e103990c2d0b08 \
-  && go get github.com/Financial-Times/vulcan-session-auth/sauth \
-  && go get github.com/mailgun/vulcand/vbundle \
-  && go get github.com/mailgun/log \
-  && cd $GOPATH/src/${REPO_PATH} \
-  && vbundle init --middleware=github.com/Financial-Times/vulcan-session-auth/sauth \
-  && go build -o vulcand \
+  && go get github.com/Financial-Times/vulcand \
+  && cd $GOPATH/src/github.com/Financial-Times/vulcand \
+  && git checkout daaa02dfc0d1d5e6f34440825008a743cc5b442f \
+  && go build -o /vulcand \
   && apk del go git \
   && rm -rf /var/cache/apk/*
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-#FT-vulcan
+# FT-vulcan
 
-Version of vulcan that comes bundled with plugins:
+Docker image vulcan that is based on [FT fork][1]
 
- - https://github.com/Financial-Times/vulcan-session-auth
+[1]: https://github.com/Financial-Times/vulcand
+


### PR DESCRIPTION
- No longer needs to do auth (moved to Varnish)
- Latest [vulcand PR](https://github.com/Financial-Times/vulcand/pull/3)
  allows vulcan to start unhealthy and report on misconfigured config.
